### PR TITLE
The latest requests library removes config and 'max-retries'

### DIFF
--- a/pyfaceb/api.py
+++ b/pyfaceb/api.py
@@ -10,7 +10,6 @@ from .exceptions import (FBException, FBHTTPException, FBJSONException,
 BASE_GRAPH_URL = "https://graph.facebook.com"
 BATCH_QUERY_LIMIT = 50
 TIMEOUT = 60.0
-REQUESTS_CONFIG = {'max_retries': 2}
 VERIFY_SSL = False
 
 log = logging.getLogger(__name__)
@@ -155,7 +154,7 @@ class FBGraph(object):
 
         self._exec_hook('pre')
         try:
-            r = requests.request(method, url, config=REQUESTS_CONFIG, **kwargs)
+            r = requests.request(method, url, **kwargs)
         except (SSLError, Timeout) as e:
             raise FBConnectionException(e.message)
         self._exec_hook('post')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-requests>=0.10
-mock>=0.8.0
+mock==1.0.1
+requests==1.1.0


### PR DESCRIPTION
This commit disables the max-retries option, rather than reverting the `requirements.txt` file.  This allows pyfaceb to use the latest versions of `requests`.
